### PR TITLE
Add --cfg.file_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ usage: worker.py [-h]
 
 # ③ Data loading - optional settings
 [--cfg.function CFG.FUNCTION] # Name of the table function for accessing the to-be-loaded files
+[--cfg.file_prefix CFG.FILE_PREFIX] # A prefix to the file path
 [--cfg.bucket_access_key CFG.ACCESS_KEY] # Access key for the object storage bucket hosting the files to be loaded
 [--cfg.bucket_access_secret CFG.ACCESS_SECRET] # Access secret for the object storage bucket hosting the files to be loaded
 [--cfg.format CFG.FORMAT] # Name of the file format used

--- a/src/worker.py
+++ b/src/worker.py
@@ -91,6 +91,9 @@ ap.add_argument("--table", required=True,
 ap.add_argument("--cfg.function", required=False, default='s3',
                 help='Name of the table function for accessing the to-be-loaded files.')
 
+ap.add_argument("--cfg.file_prefix", required=False, default='',
+                help='A prefix to the file path.')
+
 ap.add_argument("--cfg.bucket_access_key", required=False)
 ap.add_argument("--cfg.bucket_access_secret", required=False)
 
@@ -308,7 +311,7 @@ def create_batch_load_command(file_url, db_staging, tbl_staging, configuration):
 
     command = f"""
             INSERT INTO {db_staging}.{tbl_staging}
-            {query_clause_fragments['select_fragment']} FROM {query_clause_fragments['function_fragment']}'{file_url}'{query_clause_fragments['access_fragment']}{query_clause_fragments['format_fragment']}{query_clause_fragments['structure_fragment']})
+            {query_clause_fragments['select_fragment']} FROM {query_clause_fragments['function_fragment']}'{query_clause_fragments['file_prefix_fragment']}{file_url}'{query_clause_fragments['access_fragment']}{query_clause_fragments['format_fragment']}{query_clause_fragments['structure_fragment']})
             {query_clause_fragments['filter_fragment']}
             {query_clause_fragments['settings_fragment']}
         """
@@ -335,6 +338,7 @@ def to_query_clause_fragments(configuration):
 
     return {
         'function_fragment': f"""{configuration['function']}(""",
+        'file_prefix_fragment': configuration['file_prefix'],
         'access_fragment': access_fragment,
         'select_fragment': f"""{configuration['select']} """,
         'format_fragment': f""", '{configuration['format']}'""" if 'format' in configuration else '',
@@ -619,6 +623,7 @@ def move_partition(partition_id, db_src, tbl_src, db_dst, tbl_dst, client):
 def to_configuration_dictionary(args):
     configuration = {}
     add_to_dictionary_if_present(configuration, args, 'cfg.function', 'function')
+    add_to_dictionary_if_present(configuration, args, 'cfg.file_prefix', 'file_prefix')
     add_to_dictionary_if_present(configuration, args, 'cfg.bucket_access_key', 'bucket_access_key')
     add_to_dictionary_if_present(configuration, args, 'cfg.bucket_access_secret', 'bucket_access_secret')
     add_to_dictionary_if_present(configuration, args, 'cfg.format', 'format')


### PR DESCRIPTION
Thanks for the tool!

Adding a file prefix arg to worker.py for convenience.
I need to load a ton of files (millions) from S3 and the paths are like
```
https://aaa-bucket.s3.amazonaws.com/xxx/yyy/zzz.1596841695464.6664017b9e4a236b8e
https://aaa-bucket.s3.amazonaws.com/xxx/yyy/zzz.1596841879063.38315364f8f0b286cb
...
```
The common prefix is `https://aaa-bucket.s3.amazonaws.com/xxx/yyy/`
And instead of generating a giant file with all the paths containing the same prefix and then storing them into `tasks` table it will be much efficient to specify it once as an arg to the script.

In my case, the working example to be:
```
python ClickLoad/src/worker.py \
    --host ${CLICKHOUSE_HOST} \
    --port ${CLICKHOUSE_PORT} \
    --username ${CLICKHOUSE_USER} \
    --password ${CLICKHOUSE_PASSWORD} \
    --task_database ${DB} \
    --worker_id="worker_${i}" \
    --task_table tasks \
    --database bbbstats \
    --table s3_loaded_data \
    --cfg.function "s3" \
    --cfg.file_prefix "https://aaa-bucket.s3.amazonaws.com/xxx/yyy/" \
    --cfg.format JSONAsString \
    --cfg.structure  "data String', 'gzip" \
    --cfg.select "SELECT splitByChar('/', _path)[2] as tenant, _file as s3_file, fromUnixTimestamp64Milli(toInt64(extractAll(_file, '\\d+')[1])) as time, data" \
    --cfg.query_settings input_format_null_as_default=1 input_format_parquet_import_nested=1 max_insert_threads=1 min_insert_block_size_bytes=0 min_insert_block_size_rows=1_000_000 \
```